### PR TITLE
fix(ci): use PR for changelog updates, improve format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: actions/setup-java@v4
         with:
@@ -50,14 +49,21 @@ jobs:
           config: cliff.toml
           args: --output CHANGELOG.md
 
-      - name: Commit changelog
+      - name: Create changelog PR
         if: steps.release.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="chore/changelog-update-$(date +%s)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+          git checkout -b "$BRANCH"
           git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "chore: update changelog [skip ci]"
-          git push
+          git diff --cached --quiet && echo "No changelog changes" && exit 0
+          git commit -m "chore: update changelog [skip ci]"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: update changelog" \
+            --body "Auto-generated changelog update from release workflow." \
+            --base main \
+            --head "$BRANCH"

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,25 +4,26 @@ header = """# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 """
 body = """
-{%- macro remote_url() -%}
-  https://github.com/swatarianess/qorche
-{%- endmacro -%}
-
 {% if version -%}
 ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
 ## [Unreleased]
 {% endif -%}
 
-{% for group, commits in commits | group_by(attribute="group") %}
+{% for group, commits in commits | group_by(attribute="group") -%}
 ### {{ group | upper_first }}
-{% for commit in commits %}
-- {% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message | upper_first | trim }}\
-{% endfor %}
-{% endfor %}
+
+{% for commit in commits -%}
+{%- if commit.scope -%}
+- **{{ commit.scope }}**: {{ commit.message | trim }}
+{% else -%}
+- {{ commit.message | trim }}
+{% endif -%}
+{%- endfor %}
+{% endfor -%}
 """
 footer = ""
 trim = true


### PR DESCRIPTION
## Summary
- Release workflow now creates a PR for changelog updates instead of pushing directly to main
- Respects branch protection rules
- Improved cliff.toml template: scoped commits show scope in bold, cleaner formatting

## What changed
- `.github/workflows/release.yml` — changelog step creates a branch + PR instead of direct push
- `cliff.toml` — cleaner template with `**scope**: message` format