### PR TITLE
fix(core): add timeout to ClaudeCodeAdapter, fix DiffCommand ID lookup, stabilize topological sort

### DIFF
--- a/agent/src/main/kotlin/io/qorche/agent/ClaudeCodeAdapter.kt
+++ b/agent/src/main/kotlin/io/qorche/agent/ClaudeCodeAdapter.kt
@@ -7,8 +7,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
-class ClaudeCodeAdapter : AgentRunner {
+/**
+ * Runs Claude Code CLI as a child process.
+ * @param timeoutSeconds Maximum time to wait for the process to complete.
+ */
+class ClaudeCodeAdapter(
+    private val timeoutSeconds: Long = 300
+) : AgentRunner {
 
     override fun run(
         instruction: String,
@@ -29,8 +36,14 @@ class ClaudeCodeAdapter : AgentRunner {
                 }
             }
 
-            val exitCode = process.waitFor()
-            emit(AgentEvent.Completed(exitCode))
+            val completed = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+            if (!completed) {
+                process.destroyForcibly()
+                emit(AgentEvent.Error("Process timed out after ${timeoutSeconds}s"))
+                emit(AgentEvent.Completed(exitCode = 124))
+                return@flow
+            }
+            emit(AgentEvent.Completed(process.exitValue()))
         } catch (e: Exception) {
             emit(AgentEvent.Error(e.message ?: "Unknown error"))
             emit(AgentEvent.Completed(exitCode = 1))

--- a/cli/src/main/kotlin/io/qorche/cli/Commands.kt
+++ b/cli/src/main/kotlin/io/qorche/cli/Commands.kt
@@ -228,8 +228,8 @@ class DiffCommand : CliktCommand(name = "diff") {
         }
 
         val allSnapshots = orchestrator.history()
-        val fullId1 = allSnapshots.find { it.id.startsWith(resolvedId2) }?.id ?: resolvedId2
-        val fullId2 = allSnapshots.find { it.id.startsWith(id1) }?.id ?: id1
+        val fullId1 = allSnapshots.find { it.id.startsWith(id1) }?.id ?: id1
+        val fullId2 = allSnapshots.find { it.id.startsWith(resolvedId2) }?.id ?: resolvedId2
 
         val diff = orchestrator.diffSnapshots(fullId1, fullId2)
         if (diff == null) {

--- a/core/src/main/kotlin/io/qorche/core/TaskGraph.kt
+++ b/core/src/main/kotlin/io/qorche/core/TaskGraph.kt
@@ -33,7 +33,7 @@ class TaskGraph(definitions: List<TaskDefinition>) {
             result.add(id)
         }
 
-        for (id in nodes.keys) {
+        for (id in nodes.keys.sorted()) {
             visit(id)
         }
         return result
@@ -93,7 +93,7 @@ class TaskGraph(definitions: List<TaskDefinition>) {
             black.add(id)
         }
 
-        for (id in nodes.keys) {
+        for (id in nodes.keys.sorted()) {
             if (id in white) {
                 dfs(id, mutableListOf())
             }

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1,7 +1,7 @@
 # Qorche — Implementation Progress
 
-**Current milestone**: M2 (in progress)
-**Last updated**: 2026-03-22
+**Current milestone**: Post-M3 (native library, retry-on-conflict)
+**Last updated**: 2026-03-25
 
 ---
 
@@ -98,16 +98,30 @@ At 5k files: M0 was 0.6x (slower), M1 is 1.4x (faster).
 
 ---
 
-## M3: Parallel execution + MVCC conflict detection (not started)
+## M3: Parallel execution + MVCC conflict detection [COMPLETE]
 
-### Tasks
-- [ ] Execute parallel groups concurrently via coroutines
-- [ ] MVCC conflict detection after parallel task completion
-- [ ] Conflict resolution strategy (fail-fast or merge)
-- [ ] Update benchmarks to measure real parallel execution (not just simulated)
-- [ ] WAL entries for conflict events
-- [ ] Test: two agents modify same file → conflict detected
-- [ ] Test: two agents modify different files → no conflict, both succeed
+**Current milestone**: Post-M3 (native library, retry-on-conflict)
+**Last updated**: 2026-03-25
+
+### Done
+- [x] `Orchestrator.runGraphParallel()` — concurrent execution within parallel groups via coroutines
+- [x] MVCC conflict detection after parallel group completion (pairwise hash set intersection)
+- [x] Conflict resolution strategy: fail-fast (conflicting tasks FAILED, dependents SKIPPED)
+- [x] Scope audit — detects undeclared writes outside task file scopes with group-level attribution
+- [x] `WALEntry.ConflictDetected` and `WALEntry.ScopeViolation` for audit trail
+- [x] `ConflictDetector.detectGroupConflicts()` with O(n²) scaling documented
+- [x] `ConflictDetector.detectScopeViolations()` — group-level, honest attribution
+- [x] `FileIndex` fixed for concurrent access (`ConcurrentHashMap`)
+- [x] Parallel execution benchmarks — 10.7x speedup at 12 independent tasks
+- [x] Diamond DAG benchmarks — near-theoretical-floor parallel timing
+- [x] DAG propagation benchmarks — 500-node chain in 34ms, fan-out in 4ms
+- [x] Realistic file size benchmarks — warm snapshot parity (1.0x) validates mtime cache
+- [x] Real-process integration tests with concurrent disk writes
+- [x] Tests: ParallelExecutionTest (12), benchmark tests (3 new)
+
+### Remaining (deferred)
+- [ ] Retry-on-conflict strategy (re-run loser against updated state)
+- [ ] Cold-start benchmark (no FileIndex, no caches)
 
 ---
 


### PR DESCRIPTION
## Summary
- **ClaudeCodeAdapter**: Add configurable timeout (default 300s) — previously could hang indefinitely
- **DiffCommand**: Fix reversed snapshot ID resolution (`fullId1`/`fullId2` were swapped)
- **TaskGraph**: Use `nodes.keys.sorted()` for deterministic topological sort across runs
- **IMPLEMENTATION.md**: Update to reflect M3 completion

## Test plan
- [x] `./gradlew test` passes (all existing tests unaffected)
- [x] CI passes on PR