### PR TITLE
feat(ci): add GraalVM native-image build with cross-platform CI

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,64 @@
+name: Native Build
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: qorche-linux-amd64
+            binary: cli/build/native/nativeCompile/qorche
+          - os: windows-latest
+            artifact: qorche-windows-amd64.exe
+            binary: cli/build/native/nativeCompile/qorche.exe
+          - os: macos-latest
+            artifact: qorche-macos-arm64
+            binary: cli/build/native/nativeCompile/qorche
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: 21
+          distribution: graalvm-community
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Build native image
+        run: ./gradlew :cli:nativeCompile
+
+      - name: Verify binary runs
+        shell: bash
+        run: |
+          "${{ matrix.binary }}" version
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.binary }}
+
+      - name: Attach to release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp "${{ matrix.binary }}" "${{ matrix.artifact }}"
+          gh release upload "${{ github.event.release.tag_name }}" "${{ matrix.artifact }}" --clobber

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -37,7 +37,13 @@ graalvmNative {
         named("main") {
             mainClass.set("io.qorche.cli.MainKt")
             imageName.set("qorche")
-            buildArgs.add("--no-fallback")
+            buildArgs.addAll(
+                "--no-fallback",
+                "-H:+ReportExceptionStackTraces"
+            )
         }
+    }
+    metadataRepository {
+        enabled.set(true)
     }
 }

--- a/cli/src/main/resources/META-INF/native-image/io.qorche/cli/jni-config.json
+++ b/cli/src/main/resources/META-INF/native-image/io.qorche/cli/jni-config.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "org.sqlite.core.NativeDB",
+    "methods": [
+      {"name": "<init>", "parameterTypes": []},
+      {"name": "_open_utf8", "parameterTypes": ["byte[]", "int"]},
+      {"name": "_close", "parameterTypes": []},
+      {"name": "_exec_utf8", "parameterTypes": ["byte[]"]},
+      {"name": "_prepare_utf8", "parameterTypes": ["long", "byte[]"]},
+      {"name": "_finalize", "parameterTypes": ["long"]},
+      {"name": "_step", "parameterTypes": ["long"]},
+      {"name": "_reset", "parameterTypes": ["long"]},
+      {"name": "_column_count", "parameterTypes": ["long"]},
+      {"name": "_column_type", "parameterTypes": ["long", "int"]},
+      {"name": "_column_text_utf8", "parameterTypes": ["long", "int"]},
+      {"name": "_column_int", "parameterTypes": ["long", "int"]},
+      {"name": "_column_long", "parameterTypes": ["long", "int"]},
+      {"name": "_column_double", "parameterTypes": ["long", "int"]},
+      {"name": "_column_blob", "parameterTypes": ["long", "int"]},
+      {"name": "_column_name_utf8", "parameterTypes": ["long", "int"]},
+      {"name": "_changes", "parameterTypes": []},
+      {"name": "_total_changes", "parameterTypes": []},
+      {"name": "throwex", "parameterTypes": []}
+    ],
+    "allDeclaredFields": true
+  }
+]

--- a/cli/src/main/resources/META-INF/native-image/io.qorche/cli/native-image.properties
+++ b/cli/src/main/resources/META-INF/native-image/io.qorche/cli/native-image.properties
@@ -1,0 +1,3 @@
+Args = --initialize-at-build-time=kotlinx.coroutines,kotlinx.serialization,kotlin \
+       --initialize-at-run-time=io.qorche \
+       -H:+ReportExceptionStackTraces

--- a/cli/src/main/resources/META-INF/native-image/io.qorche/cli/resource-config.json
+++ b/cli/src/main/resources/META-INF/native-image/io.qorche/cli/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": "io/qorche/cli/version.txt"},
+      {"pattern": "org/sqlite/.*"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Add GraalVM native-image compilation to produce standalone binaries with no JVM dependency.

**What this enables:**
- `qorche` as a single binary (~20-30MB) — instant startup, low memory
- No Java installation needed on target machine
- Cross-platform: Linux amd64, Windows amd64, macOS arm64

**Changes:**
- Native-image metadata for sqlite-jdbc JNI registration
- Resource config for version.txt and SQLite native libraries
- kotlinx initialization config for build-time/run-time split
- GraalVM metadata repository enabled for library compatibility
- CI workflow: builds on all 3 platforms, attaches to GitHub Releases
- Manual trigger (`workflow_dispatch`) for testing

**How it works:**
1. `semantic-release` creates a GitHub Release (existing flow)
2. `native-build` workflow triggers on `release: published`
3. Builds native binary on Linux, Windows, macOS in parallel
4. Attaches all three binaries to the Release

## Test plan
- [x] CI passes on PR (JVM tests only — no GraalVM in test workflow)
- [x] Manual `workflow_dispatch` trigger builds successfully
- [x] Binary runs `qorche version` correctly