### PR TITLE
fix(ci): add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - '**.kt'
       - '**.kts'
       - 'gradle/**'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Allows manual triggering of the release workflow. Fixes missed release for PR #12.