### PR TITLE
fix(ci): disable UPX on Windows, GraalVM PE binaries incompatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,12 +79,11 @@ jobs:
         run: ./gradlew :cli:nativeCompile
 
       - name: Compress with UPX
-        if: matrix.os != 'macos-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: svenstaro/upx-action@v2
         with:
           files: ${{ matrix.binary }}
           args: --best --lzma
-          strip: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Verify binary runs
         shell: bash


### PR DESCRIPTION
UPX compresses the binary but the result can't run (exit code 193). Known incompatibility with GraalVM CE 21.0.2 PE format. Linux UPX stays.