### PR TITLE
fix(ci): add dual trigger for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,7 +15,10 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     outputs:
       new_release: ${{ steps.release.outputs.new_release_published }}
@@ -45,7 +51,9 @@ jobs:
 
   native-build:
     needs: release
-    if: needs.release.outputs.new_release == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      needs.release.outputs.new_release == 'true' ||
+      github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- Add `pull_request: closed` as a fallback trigger alongside `push: branches: [main]`
- Root cause: the CI changelog job pushes a commit using `GITHUB_TOKEN` → when that becomes the PR HEAD and the PR is merged, GitHub suppresses the `push` event on main
- Evidence: PR #23 (YAML-only, no CI/changelog run) triggered the release ✓, PR #24 (code changes, CI/changelog ran) did not ✗
- With both triggers, at least one will always fire regardless of GITHUB_TOKEN interference

## Test plan
- [x] Merge this PR → release triggers via `push` (this is a YAML-only change, no changelog interference)
- [x] Merge a subsequent code PR → release triggers via `pull_request: closed` fallback