### PR TITLE
feat(core): serializable API, Result error handling, tests, and doc cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Release
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,10 +12,7 @@ permissions:
 
 jobs:
   release:
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       new_release: ${{ steps.release.outputs.new_release_published }}


### PR DESCRIPTION
## Summary
- **CI fix:** Remove `pull_request: closed` trigger (caused duplicate release runs on wrong branch)
- **feat(core):** Add `@Serializable` to all public result types (RunResult, GraphResult, TaskOutcome, ConflictDetector data classes)
- **feat(core):** Change `runTask()` to return `Result<RunResult>` instead of throwing for expected agent failures
- **test:** Add 17 new tests — Orchestrator edge cases (8) and serialization round-trip verification (9)
- **docs:** Mark Phase 1/M3/CLI roadmap complete, remove WORKPLAN.md

## Breaking changes
- `runTask()` now returns `Result<RunResult>` — callers must use `.getOrThrow()` or handle the Result

## Test plan
- [x] All 52 tests pass
- [ ] CI passes on Ubuntu + Windows
- [ ] Merging triggers single release run on main (push event only)
- [ ] semantic-release creates a minor version bump (feat: commits)