### PR TITLE
fix(ci): move changelog generation from CI to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,3 @@ jobs:
           name: test-reports-${{ matrix.os }}
           path: '**/build/reports/tests/'
 
-  changelog:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-
-      - name: Generate changelog
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --output CHANGELOG.md
-
-      - name: Commit changelog
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet && echo "No changelog changes" && exit 0
-          git commit -m "chore: update changelog [skip ci]"
-          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate changelog
+        if: steps.release.outputs.new_release_published == 'true'
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+
+      - name: Commit changelog
+        if: steps.release.outputs.new_release_published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet && echo "No changelog changes" && exit 0
+          git commit -m "chore: update changelog [skip ci]"
+          git push
+
   native-build:
     needs: release
     if: >-


### PR DESCRIPTION
## Summary
- Remove changelog job from CI workflow (was pushing GITHUB_TOKEN commits to PR branches, suppressing push events on merge)
- Add changelog generation to release workflow, after semantic-release creates the tag
- This is the root cause of release workflows not triggering on PR merge

## New flow
1. PR opened → CI runs tests only (no git push)
2. PR merged → push event fires on main (no GITHUB_TOKEN suppression)
3. Release workflow → tests → semantic-release (tag) → changelog → native builds

## Test plan
- [ ] CI runs on this PR with tests only (no changelog commit pushed)
- [ ] Merging triggers release workflow via push event
- [ ] semantic-release creates a new version
- [ ] Changelog is updated after tagging