### PR TITLE
fix(ci): remove changelog commit from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,25 +43,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate changelog
-        if: steps.release.outputs.new_release_published == 'true'
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --output CHANGELOG.md
-
-      - name: Commit changelog
-        if: steps.release.outputs.new_release_published == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet && echo "No changelog changes" && exit 0
-          git commit -m "chore: update changelog [skip ci]"
-          git push
-
   native-build:
     needs: release
     if: >-


### PR DESCRIPTION
## Summary
- Remove changelog generation and commit steps from release workflow
- Branch protection rules block direct GITHUB_TOKEN pushes to main (`GH013`)
- Changelog in repo is redundant — semantic-release generates release notes on the GitHub Release page
- This should be the final fix for the release pipeline

## Test plan
- [x] Merging triggers release workflow
- [x] semantic-release creates a new version (picks up unreleased fix: commits)
- [x] No GH013 error — no direct push to main attempted
- [x] Native builds run successfully