### PR TITLE
chore: configure two-branch release model (main=stable, develop=alpha)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,8 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main",
+    {"name": "develop", "prerelease": "alpha"}
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Summary
- Configure semantic-release with two-branch model:
  - `main` → stable releases (1.0.0, 1.1.0, ...)
  - `develop` → alpha pre-releases (v0.1.0-alpha.1, v0.1.0-alpha.2, ...)
- Update release workflow to trigger on both `main` and `develop` pushes

## Workflow
```
feature-branch → PR → develop (alpha release with binaries)
                         ↓
                    develop → PR → main (stable release)
```

## Test plan
- Merge this PR, then merge a `feat:` commit to `develop`
- Verify it produces a `v0.x.0-alpha.1` pre-release tag