### PR TITLE
feat: JSON Schema for tasks.yaml with editor integration (VEN-50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,24 @@ print(f"Project: {data['project']}, Tasks: {data['task_count']}")
 | `history`  | List past snapshots                                                        |
 | `diff`     | Show file changes between two snapshots                                    |
 | `clean`    | Remove stored data from .qorche/                                           |
+| `schema`   | Print JSON Schema for tasks.yaml (editor autocomplete and validation)      |
 | `version`  | Print version                                                              |
 
 JSON output available via `--output json` on `run` and `plan` commands.
+
+### Editor integration
+
+Use `qorche schema` to get autocomplete and validation in your editor:
+
+```bash
+# Add modeline to your tasks.yaml
+# yaml-language-server: $schema=https://qorche.dev/schema/tasks.json
+
+# Or export locally for offline use
+qorche schema --output .qorche/tasks.schema.json
+```
+
+Supports VS Code (Red Hat YAML), IntelliJ (native), and nvim (yaml-language-server).
 
 ## Project structure
 
@@ -309,7 +324,7 @@ JSON output available via `--output json` on `run` and `plan` commands.
 qorche/
 ├── core/       # Orchestrator, snapshots, MVCC, DAG, WAL (zero domain-specific deps)
 ├── agent/      # Runner implementations (MockAgentRunner, ShellRunner, ClaudeCodeAdapter)
-├── cli/        # CLI entry point via Clikt (run, plan, init, validate, status, logs, diff, clean)
+├── cli/        # CLI entry point via Clikt (run, plan, init, validate, status, logs, diff, clean, schema)
 └── native/     # Shared library (libqorche) via GraalVM --shared, C FFI entry points
 ```
 

--- a/cli/detekt-baseline.xml
+++ b/cli/detekt-baseline.xml
@@ -7,7 +7,6 @@
     <ID>LongMethod:InitCommand.kt$internal fun generateTasksYaml(type: ProjectType, workDir: Path): String</ID>
     <ID>LoopWithTooManyJumpStatements:JsonOutput.kt$for</ID>
     <ID>MaxLineLength:Commands.kt$QorcheCommand$override fun help(context: com.github.ajalt.clikt.core.Context)</ID>
-    <ID>MaxLineLength:Commands.kt$QorcheCommand$subcommands(InitCommand(), RunCommand(), PlanCommand(), ValidateCommand(), StatusCommand(), LogsCommand(), HistoryCommand(), DiffCommand(), CleanCommand(), VersionCommand())</ID>
     <ID>MaxLineLength:Commands.kt$RunCommand$"hashing" -&gt; echo("\r${Terminal.dim("Hashing ${progress.current}/${progress.total} files...")}", trailingNewline = false)</ID>
     <ID>MaxLineLength:Commands.kt$RunCommand$TaskStatus.FAILED -&gt; echo("${Terminal.red("[${taskId}]")} FAILED: ${outcome.skipReason ?: "non-zero exit"} ${Terminal.dim("(${formatElapsed(outcome.elapsedMs)})")}")</ID>
     <ID>MaxLineLength:Commands.kt$RunCommand$echo("${Terminal.red("[CONFLICT]")} ${conflict.taskA} &lt;-&gt; ${conflict.taskB}: ${conflict.conflictingFiles.joinToString(", ")}")</ID>

--- a/cli/src/main/kotlin/io/qorche/cli/Commands.kt
+++ b/cli/src/main/kotlin/io/qorche/cli/Commands.kt
@@ -42,7 +42,11 @@ class QorcheCommand : CliktCommand(name = "qorche") {
 
     init {
         completionOption()
-        subcommands(InitCommand(), RunCommand(), PlanCommand(), ValidateCommand(), StatusCommand(), LogsCommand(), HistoryCommand(), DiffCommand(), CleanCommand(), VersionCommand())
+        subcommands(
+            InitCommand(), RunCommand(), PlanCommand(), ValidateCommand(),
+            StatusCommand(), LogsCommand(), HistoryCommand(), DiffCommand(),
+            CleanCommand(), SchemaCommand(), VersionCommand()
+        )
     }
 }
 
@@ -369,6 +373,27 @@ class DiffCommand : CliktCommand(name = "diff") {
         for (f in diff.added.sorted()) echo("  + $f")
         for (f in diff.modified.sorted()) echo("  ~ $f")
         for (f in diff.deleted.sorted()) echo("  - $f")
+    }
+}
+
+class SchemaCommand : CliktCommand(name = "schema") {
+    override fun help(context: com.github.ajalt.clikt.core.Context) =
+        "Print the JSON Schema for tasks.yaml (for editor autocomplete and validation)"
+
+    private val output by option("--output", "-o", help = "Write schema to a file instead of stdout")
+
+    override fun run() {
+        val schema = javaClass.getResourceAsStream("/io/qorche/cli/tasks.schema.json")
+            ?.bufferedReader()?.readText()
+            ?: error("Schema resource not found")
+
+        if (output != null) {
+            val path = java.nio.file.Path.of(output!!)
+            path.toFile().writeText(schema)
+            echo("Schema written to $output")
+        } else {
+            echo(schema)
+        }
     }
 }
 

--- a/cli/src/main/resources/META-INF/native-image/io.qorche/cli/resource-config.json
+++ b/cli/src/main/resources/META-INF/native-image/io.qorche/cli/resource-config.json
@@ -1,7 +1,8 @@
 {
   "resources": {
     "includes": [
-      {"pattern": "io/qorche/cli/version.txt"}
+      {"pattern": "io/qorche/cli/version.txt"},
+      {"pattern": "io/qorche/cli/tasks.schema.json"}
     ]
   }
 }

--- a/cli/src/main/resources/io/qorche/cli/tasks.schema.json
+++ b/cli/src/main/resources/io/qorche/cli/tasks.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qorche.dev/schema/tasks.json",
+  "title": "Qorche Task Definition",
+  "description": "Defines a project with a DAG of tasks for concurrent filesystem orchestration. Qorche coordinates parallel workers with MVCC-inspired conflict detection.",
+  "type": "object",
+  "required": ["project", "tasks"],
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project name. Used in snapshots, WAL entries, and output.",
+      "examples": ["auth-refactor", "my-project"]
+    },
+    "runners": {
+      "type": "object",
+      "description": "Named runner configurations. Each key is a runner name that tasks can reference via the 'runner' field. When omitted, all tasks use the default CLI runner.",
+      "additionalProperties": {
+        "$ref": "#/$defs/runner_config"
+      },
+      "examples": [
+        {
+          "claude": {
+            "type": "claude-code",
+            "extra_args": ["--dangerously-skip-permissions"]
+          },
+          "shell": {
+            "type": "shell",
+            "allowed_commands": ["npm", "gradle", "pytest"]
+          }
+        }
+      ]
+    },
+    "tasks": {
+      "type": "array",
+      "description": "Ordered list of task definitions forming a DAG. Tasks execute in dependency order, with independent tasks running in parallel.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/task"
+      }
+    }
+  },
+  "$defs": {
+    "runner_config": {
+      "type": "object",
+      "description": "Configuration for a named runner.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Runner type identifier. Determines which AgentRunner implementation is used.",
+          "examples": ["claude-code", "shell"]
+        },
+        "model": {
+          "type": "string",
+          "description": "Model name for LLM-backed runners (e.g. 'qwen2.5-coder:7b').",
+          "examples": ["qwen2.5-coder:7b", "claude-sonnet-4-20250514"]
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Service endpoint URL (e.g. for Ollama or remote runners).",
+          "format": "uri",
+          "examples": ["http://localhost:11434"]
+        },
+        "extra_args": {
+          "type": "array",
+          "description": "Additional command-line arguments passed to the runner process.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["--dangerously-skip-permissions"]]
+        },
+        "allowed_commands": {
+          "type": "array",
+          "description": "Permitted executables for shell runners. Required when type is 'shell'.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["npm", "gradle", "pytest"]]
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "description": "Maximum execution time in seconds per task invocation.",
+          "default": 300,
+          "minimum": 1
+        }
+      }
+    },
+    "task": {
+      "type": "object",
+      "description": "A single task in the execution DAG.",
+      "required": ["id", "instruction"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier within the project. Used as the DAG node key and in log filenames.",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$",
+          "examples": ["explore", "backend", "run-tests"]
+        },
+        "instruction": {
+          "type": "string",
+          "description": "Free-text instruction passed to the runner. For shell runners, this is the command to execute.",
+          "examples": [
+            "Refactor the auth module to use JWT tokens",
+            "pytest src/ --tb=short"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Classification of work. Used for reporting and future scheduling heuristics.",
+          "enum": ["explore", "implement", "verify", "test"],
+          "default": "implement"
+        },
+        "depends_on": {
+          "type": "array",
+          "description": "IDs of tasks that must complete successfully before this task starts. Forms the DAG edges.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["explore"], ["backend", "frontend"]]
+        },
+        "files": {
+          "type": "array",
+          "description": "Declared file scope - paths this task is expected to modify. Used for scoped snapshots and scope-violation auditing. Supports files and directories.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["src/auth/login.ts", "src/auth/types.ts"], ["src/", "tests/"]]
+        },
+        "max_retries": {
+          "type": "integer",
+          "description": "Maximum retry attempts when this task loses an MVCC conflict. 0 means no retries.",
+          "default": 0,
+          "minimum": 0
+        },
+        "runner": {
+          "type": "string",
+          "description": "Name of the runner to use for this task, referencing a key in the top-level 'runners' map. When omitted, the default CLI runner is used.",
+          "examples": ["claude", "shell", "ollama"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add JSON Schema defining the full `tasks.yaml` contract (project, runners, tasks with all fields, descriptions, examples, enums)
- Add `qorche schema` CLI command to output the schema (stdout or `--output` file)
- Bundle schema as a CLI resource with GraalVM native-image support
- Document editor integration in README (VS Code, IntelliJ, nvim)

## Editor usage

```yaml
# yaml-language-server: $schema=https://qorche.dev/schema/tasks.json
project: my-project
tasks: ...
```

Or export locally: `qorche schema --output .qorche/tasks.schema.json`

## Test plan
- [x] `qorche schema` outputs valid JSON Schema to stdout
- [x] `qorche schema --output file.json` writes schema to file
- [x] All existing tests pass
- [x] Detekt clean
- [x] Manual: validate schema with an editor (yaml-language-server)

Closes VEN-50