### PR TITLE
fix: fetch tags in docs workflow for correct version display

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` and `fetch-tags: true` to docs workflow checkout
- Without tags, `git describe --tags --long` fails and version defaults to `0.0.0-dev`

## Test plan
- [x] Re-run docs workflow after merge — version should show `1.0.0-alpha.4`