### PR TITLE
docs: show native/ dependency on agent/ in L2 diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ graph TB
     Agent -->|"implements AgentRunner<br/>interface defined in"| Core
     Agent -->|"spawns and manages"| Workers
     Native -->|"exposes FFI bindings for"| Core
+    Native -->|"uses built-in runners from"| Agent
     Core -->|"reads/writes"| Storage
     Core -->|"snapshots and monitors"| FS
     Workers -->|"modify files in"| FS


### PR DESCRIPTION
## Summary
- Update L2 container diagram to show native/ depending on agent/ for built-in runners
- FFI consumers need ClaudeCodeAdapter/ShellRunner, not just the core engine

Follow-up to PR #46.