### PR TITLE
chore: run CodeQL only on push to main/develop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: CodeQL
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
   schedule:
     - cron: '25 10 * * 1'
 


### PR DESCRIPTION
## Summary
- Remove `pull_request` trigger from CodeQL workflow
- CodeQL still runs on every push to main/develop and weekly schedule
- Saves ~77 min/month of Actions usage