### PR TITLE
chore: skip macOS native build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,6 @@ jobs:
           - os: windows-latest
             artifact: qorche-windows-amd64.exe
             binary: cli/build/native/nativeCompile/qorche.exe
-          - os: macos-latest
-            artifact: qorche-macos-arm64
-            binary: cli/build/native/nativeCompile/qorche
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
- Remove macOS from the native-build matrix in release.yml
- Saves ~17 min per release cycle
- Can re-enable when macOS support is needed