### PR TITLE
chore: add concurrency groups to cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ on:
       - 'gradlew.bat'
       - '.github/workflows/ci.yml'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '25 10 * * 1'
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   security-events: write
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary
- Add `concurrency` with `cancel-in-progress: true` to CI, Release, and CodeQL workflows
- Groups by workflow name + branch ref, so new pushes cancel stale runs
- Prevents duplicate runs from rapid back-to-back merges to develop