### PR TITLE
fix: keep semantic-release on 0.x versioning

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,15 @@
     {"name": "develop", "prerelease": "beta"}
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        {"breaking": true, "release": "major"},
+        {"type": "feat", "release": "minor"},
+        {"type": "fix", "release": "patch"},
+        {"type": "perf", "release": "patch"},
+        {"type": "revert", "release": "patch"}
+      ]
+    }],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ],


### PR DESCRIPTION
## Summary

- Configure `commit-analyzer` with explicit release rules so `feat:` stays as **minor** (0.1→0.2) instead of jumping to 1.0.0
- Only `feat!:` or `BREAKING CHANGE` triggers a major bump
- Ensures develop produces `v0.2.0-beta.1` (not `v1.0.0-beta.1`)

## Release rules

| Commit type | Bump |
|-------------|------|
| `feat!:` / `BREAKING CHANGE` | major |
| `feat:` | minor |
| `fix:` / `perf:` / `revert:` | patch |
| `docs:` / `chore:` / `test:` | no release |