### PR TITLE
feat: v0.2.0 release trigger

### DIFF
--- a/cli/src/main/kotlin/io/qorche/cli/InitCommand.kt
+++ b/cli/src/main/kotlin/io/qorche/cli/InitCommand.kt
@@ -85,7 +85,8 @@ internal fun detectProjectType(workDir: Path): ProjectType = when {
     Files.exists(workDir.resolve("pom.xml")) -> ProjectType.MAVEN
     Files.exists(workDir.resolve("package.json")) -> ProjectType.NODE
     Files.exists(workDir.resolve("pyproject.toml")) ||
-        Files.exists(workDir.resolve("setup.py")) -> ProjectType.PYTHON
+        Files.exists(workDir.resolve("setup.py")) ||
+        Files.exists(workDir.resolve("requirements.txt")) -> ProjectType.PYTHON
     Files.exists(workDir.resolve("Cargo.toml")) -> ProjectType.RUST
     Files.exists(workDir.resolve("go.mod")) -> ProjectType.GO
     else -> ProjectType.GENERIC

--- a/cli/src/test/kotlin/io/qorche/cli/InitCommandTest.kt
+++ b/cli/src/test/kotlin/io/qorche/cli/InitCommandTest.kt
@@ -43,6 +43,17 @@ class InitCommandTest {
     }
 
     @Test
+    fun `detects Python project via requirements txt`() {
+        val root = Files.createTempDirectory("qorche-init-test")
+        try {
+            root.resolve("requirements.txt").writeText("flask>=2.0")
+            assertEquals(ProjectType.PYTHON, detectProjectType(root))
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `detects Rust project`() {
         val root = Files.createTempDirectory("qorche-init-test")
         try {

--- a/native/Module.md
+++ b/native/Module.md
@@ -9,11 +9,16 @@ runners via a C-compatible FFI interface. Enables embedding Qorche in non-JVM la
 | Function | Description |
 |----------|-------------|
 | `qorche_version()` | Returns the library version string |
-| `qorche_validate_yaml(path)` | Validates a tasks.yaml file, returns JSON |
+| `qorche_parse_yaml(path)` | Parses a tasks.yaml file, returns full TaskProject as JSON |
+| `qorche_validate_yaml(path)` | Validates a tasks.yaml file, returns summary JSON |
 | `qorche_plan(path)` | Returns the execution plan as JSON |
-| `qorche_run(yamlPath, workDir)` | Executes a task graph with runner support |
+| `qorche_schema()` | Returns the JSON Schema for tasks.yaml |
 | `qorche_snapshot(workDir, desc)` | Creates a filesystem snapshot, returns JSON |
 | `qorche_diff(workDir, id1, id2)` | Diffs two snapshots, returns JSON |
+| `qorche_list_snapshots(workDir)` | Lists all stored snapshots as JSON array |
+| `qorche_wal_entries(workDir)` | Returns all WAL entries as JSON array |
+| `qorche_run(yamlPath, workDir)` | Executes a task graph with runner support |
+| `qorche_clean(workDir, optionsJson)` | Removes stored data (snapshots, logs, WAL) |
 | `qorche_free(ptr)` | Frees memory allocated by any of the above |
 
 All functions return UTF-8 JSON strings. Caller must free returned pointers via `qorche_free()`.

--- a/native/detekt-baseline.xml
+++ b/native/detekt-baseline.xml
@@ -3,5 +3,6 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>TooGenericExceptionCaught:QorcheApi.kt$QorcheApi$e: Exception</ID>
+    <ID>TooManyFunctions:QorcheApi.kt$QorcheApi</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/native/src/main/java/io/qorche/ffi/LibQorcheEntryPoints.java
+++ b/native/src/main/java/io/qorche/ffi/LibQorcheEntryPoints.java
@@ -38,7 +38,13 @@ public final class LibQorcheEntryPoints {
         return toCString(QorcheApi.INSTANCE.version());
     }
 
-    // ── Validation & Planning ──────────────────────────────────
+    // ── YAML & Planning ─────────────────────────────────────────
+
+    @CEntryPoint(name = "qorche_parse_yaml")
+    public static CCharPointer parseYaml(IsolateThread thread, CCharPointer yamlPath) {
+        String path = CTypeConversion.toJavaString(yamlPath);
+        return toCString(QorcheApi.INSTANCE.parseYaml(path));
+    }
 
     @CEntryPoint(name = "qorche_validate_yaml")
     public static CCharPointer validateYaml(IsolateThread thread, CCharPointer yamlPath) {
@@ -50,6 +56,11 @@ public final class LibQorcheEntryPoints {
     public static CCharPointer plan(IsolateThread thread, CCharPointer yamlPath) {
         String path = CTypeConversion.toJavaString(yamlPath);
         return toCString(QorcheApi.INSTANCE.plan(path));
+    }
+
+    @CEntryPoint(name = "qorche_schema")
+    public static CCharPointer schema(IsolateThread thread) {
+        return toCString(QorcheApi.INSTANCE.schema());
     }
 
     // ── Snapshots ──────────────────────────────────────────────
@@ -70,6 +81,20 @@ public final class LibQorcheEntryPoints {
         return toCString(QorcheApi.INSTANCE.diff(workDir, id1, id2));
     }
 
+    // ── Snapshots & History ──────────────────────────────────────
+
+    @CEntryPoint(name = "qorche_list_snapshots")
+    public static CCharPointer listSnapshots(IsolateThread thread, CCharPointer workDirPath) {
+        String workDir = CTypeConversion.toJavaString(workDirPath);
+        return toCString(QorcheApi.INSTANCE.listSnapshots(workDir));
+    }
+
+    @CEntryPoint(name = "qorche_wal_entries")
+    public static CCharPointer walEntries(IsolateThread thread, CCharPointer workDirPath) {
+        String workDir = CTypeConversion.toJavaString(workDirPath);
+        return toCString(QorcheApi.INSTANCE.walEntries(workDir));
+    }
+
     // ── Execution ──────────────────────────────────────────────
 
     @CEntryPoint(name = "qorche_run")
@@ -77,6 +102,15 @@ public final class LibQorcheEntryPoints {
         String yaml = CTypeConversion.toJavaString(yamlPath);
         String workDir = CTypeConversion.toJavaString(workDirPath);
         return toCString(QorcheApi.INSTANCE.run(yaml, workDir));
+    }
+
+    // ── Maintenance ────────────────────────────────────────────
+
+    @CEntryPoint(name = "qorche_clean")
+    public static CCharPointer clean(IsolateThread thread, CCharPointer workDirPath, CCharPointer optionsJson) {
+        String workDir = CTypeConversion.toJavaString(workDirPath);
+        String options = CTypeConversion.toJavaString(optionsJson);
+        return toCString(QorcheApi.INSTANCE.clean(workDir, options));
     }
 
     // ── Memory ─────────────────────────────────────────────────

--- a/native/src/main/kotlin/io/qorche/ffi/QorcheApi.kt
+++ b/native/src/main/kotlin/io/qorche/ffi/QorcheApi.kt
@@ -4,6 +4,7 @@ import io.qorche.agent.RunnerRegistry
 import io.qorche.core.Orchestrator
 import io.qorche.core.SnapshotCreator
 import io.qorche.core.TaskYamlParser
+import io.qorche.core.WALEntry
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -23,6 +24,13 @@ object QorcheApi {
     fun version(): String =
         javaClass.getResourceAsStream("/io/qorche/ffi/version.txt")
             ?.bufferedReader()?.readText()?.trim() ?: "dev"
+
+    fun parseYaml(yamlPath: String): String = try {
+        val project = TaskYamlParser.parseFile(Path.of(yamlPath))
+        Json.encodeToString(project)
+    } catch (e: Exception) {
+        errorJson(e.message ?: "Unknown error")
+    }
 
     fun validateYaml(yamlPath: String): String = try {
         val (project, _) = TaskYamlParser.parseFileToGraph(Path.of(yamlPath))
@@ -100,6 +108,52 @@ object QorcheApi {
     } catch (e: Exception) {
         errorJson(e.message ?: "Unknown error")
     }
+
+    fun listSnapshots(workDirPath: String): String = try {
+        val orchestrator = Orchestrator(Path.of(workDirPath))
+        Json.encodeToString(orchestrator.history())
+    } catch (e: Exception) {
+        errorJson(e.message ?: "Unknown error")
+    }
+
+    fun walEntries(workDirPath: String): String = try {
+        val orchestrator = Orchestrator(Path.of(workDirPath))
+        Json.encodeToString<List<WALEntry>>(orchestrator.walEntries())
+    } catch (e: Exception) {
+        errorJson(e.message ?: "Unknown error")
+    }
+
+    fun schema(): String = try {
+        javaClass.getResourceAsStream("/io/qorche/ffi/tasks.schema.json")
+            ?.bufferedReader()?.readText()
+            ?: errorJson("Schema resource not found")
+    } catch (e: Exception) {
+        errorJson(e.message ?: "Unknown error")
+    }
+
+    fun clean(workDirPath: String, optionsJson: String): String = try {
+        val orchestrator = Orchestrator(Path.of(workDirPath))
+        val options = Json.decodeFromString<CleanOptions>(optionsJson)
+        val result = orchestrator.clean(
+            snapshots = options.snapshots,
+            logs = options.logs,
+            wal = options.wal,
+            fileIndexCache = options.fileIndexCache,
+            keepLastSnapshots = options.keepLastSnapshots
+        )
+        Json.encodeToString(result)
+    } catch (e: Exception) {
+        errorJson(e.message ?: "Unknown error")
+    }
+
+    @kotlinx.serialization.Serializable
+    internal data class CleanOptions(
+        val snapshots: Boolean = true,
+        val logs: Boolean = true,
+        val wal: Boolean = true,
+        val fileIndexCache: Boolean = true,
+        val keepLastSnapshots: Int = 0
+    )
 
     private fun errorJson(message: String): String =
         buildJsonObject { put("error", message) }.toString()

--- a/native/src/main/resources/META-INF/native-image/io.qorche/ffi/resource-config.json
+++ b/native/src/main/resources/META-INF/native-image/io.qorche/ffi/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": "io/qorche/ffi/version.txt"},
+      {"pattern": "io/qorche/ffi/tasks.schema.json"}
+    ]
+  }
+}

--- a/native/src/main/resources/io/qorche/ffi/tasks.schema.json
+++ b/native/src/main/resources/io/qorche/ffi/tasks.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qorche.dev/schema/tasks.json",
+  "title": "Qorche Task Definition",
+  "description": "Defines a project with a DAG of tasks for concurrent filesystem orchestration. Qorche coordinates parallel workers with MVCC-inspired conflict detection.",
+  "type": "object",
+  "required": ["project", "tasks"],
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project name. Used in snapshots, WAL entries, and output.",
+      "examples": ["auth-refactor", "my-project"]
+    },
+    "default_runner": {
+      "type": "string",
+      "description": "Name of the runner to use for tasks that don't specify a 'runner' field. Must reference a key in the 'runners' map. When omitted, the shell runner is used as the default.",
+      "examples": ["claude", "shell"]
+    },
+    "runners": {
+      "type": "object",
+      "description": "Named runner configurations. Each key is a runner name that tasks can reference via the 'runner' field or 'default_runner'.",
+      "additionalProperties": {
+        "$ref": "#/$defs/runner_config"
+      },
+      "examples": [
+        {
+          "claude": {
+            "type": "claude-code",
+            "extra_args": ["--dangerously-skip-permissions"]
+          },
+          "shell": {
+            "type": "shell",
+            "allowed_commands": ["npm", "gradle", "pytest"]
+          }
+        }
+      ]
+    },
+    "verify": {
+      "$ref": "#/$defs/verify_config",
+      "description": "Optional verification step run after each parallel group completes. Use this to run tests, type checkers, or linters to validate merged state."
+    },
+    "tasks": {
+      "type": "array",
+      "description": "Ordered list of task definitions forming a DAG. Tasks execute in dependency order, with independent tasks running in parallel.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/task"
+      }
+    }
+  },
+  "$defs": {
+    "verify_config": {
+      "type": "object",
+      "description": "Configuration for a post-group verification step (test suite, type checker, linter).",
+      "required": ["command"],
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute for verification.",
+          "examples": ["./gradlew test", "npm test", "pytest", "cargo test"]
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "description": "Maximum time in seconds before the verification process is killed.",
+          "default": 300,
+          "minimum": 1
+        },
+        "on_failure": {
+          "type": "string",
+          "description": "What to do when verification fails. 'fail' aborts the pipeline, 'warn' logs the failure but continues.",
+          "enum": ["fail", "warn"],
+          "default": "fail"
+        }
+      }
+    },
+    "runner_config": {
+      "type": "object",
+      "description": "Configuration for a named runner.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Runner type identifier. Determines which AgentRunner implementation is used.",
+          "examples": ["claude-code", "shell"]
+        },
+        "model": {
+          "type": "string",
+          "description": "Model name for LLM-backed runners (e.g. 'qwen2.5-coder:7b').",
+          "examples": ["qwen2.5-coder:7b", "claude-sonnet-4-20250514"]
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Service endpoint URL (e.g. for Ollama or remote runners).",
+          "format": "uri",
+          "examples": ["http://localhost:11434"]
+        },
+        "extra_args": {
+          "type": "array",
+          "description": "Additional command-line arguments passed to the runner process.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["--dangerously-skip-permissions"]]
+        },
+        "allowed_commands": {
+          "type": "array",
+          "description": "Permitted executables for shell runners. Required when type is 'shell'.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["npm", "gradle", "pytest"]]
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "description": "Maximum execution time in seconds per task invocation.",
+          "default": 300,
+          "minimum": 1
+        }
+      }
+    },
+    "task": {
+      "type": "object",
+      "description": "A single task in the execution DAG.",
+      "required": ["id", "instruction"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier within the project. Used as the DAG node key and in log filenames.",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$",
+          "examples": ["explore", "backend", "run-tests"]
+        },
+        "instruction": {
+          "type": "string",
+          "description": "Free-text instruction passed to the runner. For shell runners, this is the command to execute.",
+          "examples": [
+            "Refactor the auth module to use JWT tokens",
+            "pytest src/ --tb=short"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Classification of work. Used for reporting and future scheduling heuristics.",
+          "enum": ["explore", "implement", "verify", "test"],
+          "default": "implement"
+        },
+        "depends_on": {
+          "type": "array",
+          "description": "IDs of tasks that must complete successfully before this task starts. Forms the DAG edges.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["explore"], ["backend", "frontend"]]
+        },
+        "files": {
+          "type": "array",
+          "description": "Declared file scope - paths this task is expected to modify. Used for scoped snapshots and scope-violation auditing. Supports files and directories.",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["src/auth/login.ts", "src/auth/types.ts"], ["src/", "tests/"]]
+        },
+        "max_retries": {
+          "type": "integer",
+          "description": "Maximum retry attempts when this task loses an MVCC conflict. 0 means no retries.",
+          "default": 0,
+          "minimum": 0
+        },
+        "runner": {
+          "type": "string",
+          "description": "Name of the runner to use for this task, referencing a key in the top-level 'runners' map. When omitted, the default CLI runner is used.",
+          "examples": ["claude", "shell", "ollama"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Empty commit with `feat:` prefix to trigger semantic-release for v0.2.0
- PR #61 was squash-merged, which collapsed all individual `feat:`/`fix:` commit prefixes into a single non-conventional commit title
- semantic-release saw "Promote develop to main for v0.2.0 release (#61)" which matches no release rule

## Root cause

GitHub's merge button defaulted to "Squash and merge" instead of "Create a merge commit". DEVELOPMENT.md documents that develop → main must use regular merge so semantic-release sees individual commit messages.

## Prevention

Configure the repo's merge button to default to "merge commit" for PRs targeting main, or disable squash merge for main-targeted PRs.